### PR TITLE
Add support for language availability check and download

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,12 @@ public class MainActivity extends Activity implements DefaultHardwareBackBtnHand
 Currently there following functionality available. All below functions return Promise , with proper error codes.
 
 - getLocales
+- checkLanguageAvailability(language)
+- downloadTTSVoice()
 - speak(args)
 - isSpeaking
 - shutDown
 - stop
-
 
 ### Importing module
 
@@ -84,13 +85,39 @@ var tts = require('react-native-android-speech')
 ```
 
 ### getLocales()
-Returns all avialbale langauges from TTS make sure that exists in device also.
+Returns all available langauges from TTS make sure that exists in device also.
 
 ## Example 
 
 ```js
 tts.getLocales().then(locales=>{
     console.log(locales)
+});
+
+```
+
+### checkLanguageAvailability(language)
+returns whether a language is available on the device TTS engine
+
+## Example 
+
+```js
+tts.checkLanguageAvailability('ko').then(result => {
+    console.log('TTS voice availability for Korean is '+result);
+});
+
+```
+
+### downloadTTSVoice()
+opens the TTS download page on the device
+
+## Example 
+
+```js
+tts.checkLanguageAvailability('ko').then(result => {
+    if (!result) {
+        downloadTTSVoice();
+    }
 });
 
 ```
@@ -118,7 +145,7 @@ tts.speak({
 
 ### isSpeaking()
 
-This method will help to figure out wheter TTS engine is currently speaking or not.
+This method will help to figure out whether TTS engine is currently speaking or not.
 
 ## Example
 

--- a/index.android.js
+++ b/index.android.js
@@ -63,6 +63,28 @@ var RNAndroidTTS = {
         }
       });
     });
+  },
+  checkLanguageAvailability(language) {
+    return new Promise((resolve,reject) => {
+      AndroidTTS.checkLanguageAvailability(language, (error,result) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(result);
+        }
+      });
+    })
+  },
+  downloadTTSVoice() {
+    return new Promise((resolve, reject) => {
+      AndroidTTS.downloadTTSVoice((error, results) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(results);
+        }
+      });
+    });
   }
 }
 module.exports = RNAndroidTTS;


### PR DESCRIPTION
Currently, the `speak` function fails silently if the requested language is not supported on the device.  To address this issue, this PR adds:

1.  Error message from `speak` that requested language is not available
2.  `checkLanguageAvailability(language)` for checking language support 
3.  `downloadTTSVoice()` for TTS Voice download page  


Together these changes will allow developers to easily detect and handle error cases where the language support is unavailable on Android device.